### PR TITLE
Skip check for io_{read,write} under 3.0

### DIFF
--- a/lib/fiber_scheduler_spec/socket_io.rb
+++ b/lib/fiber_scheduler_spec/socket_io.rb
@@ -38,6 +38,8 @@ RSpec.shared_examples FiberSchedulerSpec::SocketIO do
       end
 
       it "calls #io_read and #io_write" do
+        skip unless RUBY_VERSION >= "3.1.0"
+
         expect_any_instance_of(scheduler_class)
           .to receive(:io_read).once
           .and_call_original


### PR DESCRIPTION
They are effectively required under 3.1, but undocumented and different under 3.0.

Closes #2 